### PR TITLE
Preloader Fix

### DIFF
--- a/assets/js/sections/preloader.js
+++ b/assets/js/sections/preloader.js
@@ -59,9 +59,12 @@ class Preloader {
 	}
 
 	animateOut(req, done) {
+		
+		const intro = [config.dom.header, config.dom.form]
 
 		const tl = new TimelineMax({ paused: true, onComplete: done })
-		tl.to(this.el, 1, {autoAlpha: 1})
+		tl.to(this.el, 0, {autoAlpha: 0})
+		tl.to(intro, 0, {autoAlpha: 1})
 		tl.restart()
 	}
 

--- a/assets/less/pages/_home.less
+++ b/assets/less/pages/_home.less
@@ -15,9 +15,14 @@ Home
 		background-color: @black;
 		transform-origin: left;
 	}
+	
+	&__header {
+		.hidden();
+	}
 
 	&__form {
 		position: relative;
+		.hidden();
 
 		&--input, &--submit {
 			position: absolute;


### PR DESCRIPTION
In this PR, I fixed a case where the user sees a flash of the welcome message before the preloader is inserted into the dom. To do this, I hid the prompt header and form and then revealed them in the `animateOut` in `preloader.js`.