### PR TITLE
Restricting routing

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -64,7 +64,20 @@ class App {
 
     switch(command.type) {
       case 'route':
-        framework.go(command.data)
+        // get index of last projects
+        const projectIndex = config.hist.lastIndexOf('projects')
+
+        if (projectIndex > -1) {
+          framework.go(command.data)
+          // TODO: render 'displaying capstone'
+          // check if there is anything or only numbers after projects in history with a function
+          // console.log(command.prompt)
+          console.log(config.hist)
+          console.log(projectIndex)
+          console.log(this.index)
+        } else {
+          this.render(this.errorTemplate(userInput, commands.error))
+        }
         break
 
       case 'static':

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -87,7 +87,7 @@ class App {
   }
 
   validateProjectUsage() {
-    return config.hist.join("").match(/projects\d+$/)
+    return config.hist.join('').match(/projects\d+$/)
   }
 
   toAnchor(link) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -64,7 +64,7 @@ class App {
 
     switch(command.type) {
       case 'route':
-        if (this.validateProjectUsage() || userInput === 'home') {
+        if (this.validateUsage('projects') || userInput === 'home') {
           framework.go(command.data)
           this.render(this.commandTemplate(userInput, command.prompt, []))
         } else {
@@ -86,10 +86,10 @@ class App {
     }
   }
 
-  validateProjectUsage() {
-    const projectIndex = config.hist.lastIndexOf('projects')
-    const projectUsage = config.hist.slice(projectIndex, this.index).join("")
-    return projectUsage.match(/projects\d+$/)
+  validateUsage(command) {
+    const commandIndex = config.hist.lastIndexOf(command)
+    const choiceUsage = config.hist.slice(commandIndex+1, this.index).join("")
+    return choiceUsage.match(/\d+$/)
   }
 
   toAnchor(link) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -67,14 +67,11 @@ class App {
         // get index of last projects
         const projectIndex = config.hist.lastIndexOf('projects')
 
-        if (projectIndex > -1) {
+        if (projectIndex > -1 || userInput === 'home') {
           framework.go(command.data)
-          // TODO: render 'displaying capstone'
           // check if there is anything or only numbers after projects in history with a function
-          // console.log(command.prompt)
-          console.log(config.hist)
-          console.log(projectIndex)
-          console.log(this.index)
+
+          this.render(this.commandTemplate(userInput, command.prompt, []))
         } else {
           this.render(this.errorTemplate(userInput, commands.error))
         }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -64,7 +64,7 @@ class App {
 
     switch(command.type) {
       case 'route':
-        if (this.validateProjectUsage() || userInput === 'home') {
+        if (userInput === 'home' || this.validateProjectUsage()) {
           framework.go(command.data)
           this.render(this.commandTemplate(userInput, command.prompt, []))
         } else {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -64,13 +64,8 @@ class App {
 
     switch(command.type) {
       case 'route':
-        // get index of last projects
-        const projectIndex = config.hist.lastIndexOf('projects')
-
-        if (projectIndex > -1 || userInput === 'home') {
+        if (this.validateProjectUsage() || userInput === 'home') {
           framework.go(command.data)
-          // check if there is anything or only numbers after projects in history with a function
-
           this.render(this.commandTemplate(userInput, command.prompt, []))
         } else {
           this.render(this.errorTemplate(userInput, commands.error))
@@ -89,6 +84,12 @@ class App {
       default:
         this.render(this.errorTemplate(userInput, commands.error))
     }
+  }
+
+  validateProjectUsage() {
+    const projectIndex = config.hist.lastIndexOf('projects')
+    const projectUsage = config.hist.slice(projectIndex, this.index).join("")
+    return projectUsage.match(/projects\d+$/)
   }
 
   toAnchor(link) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -64,7 +64,7 @@ class App {
 
     switch(command.type) {
       case 'route':
-        if (this.validateUsage('projects') || userInput === 'home') {
+        if (this.validateProjectUsage() || userInput === 'home') {
           framework.go(command.data)
           this.render(this.commandTemplate(userInput, command.prompt, []))
         } else {
@@ -86,10 +86,8 @@ class App {
     }
   }
 
-  validateUsage(command) {
-    const commandIndex = config.hist.lastIndexOf(command)
-    const choiceUsage = config.hist.slice(commandIndex+1, this.index).join("")
-    return choiceUsage.match(/\d+$/)
+  validateProjectUsage() {
+    return config.hist.join("").match(/projects\d+$/)
   }
 
   toAnchor(link) {

--- a/data/data.json
+++ b/data/data.json
@@ -80,6 +80,10 @@
   "commands" : {
     "home" : {
       "type" : "route",
+      "prompt" : [
+        "loading home...",
+        "&nbsp;"
+      ],
       "data" : "/"
     },
     "about" : {
@@ -140,14 +144,26 @@
     },
     "1" : {
       "type" : "route",
+      "prompt" : [
+        "loading capstone...",
+        "&nbsp;"
+      ],
       "data" : "/project/capstone"
     },
     "2" : {
       "type" : "route",
+      "prompt" : [
+        "loading cloud metric backup system...",
+        "&nbsp;"
+      ],
       "data" : "/project/cloud-metric-backup-system"
     },
     "3" : {
       "type" : "route",
+      "prompt" : [
+        "loading frqnt flyr...",
+        "&nbsp;"
+      ],
       "data" : "/project/frqnt-flyr"
     },
     "hello" : {


### PR DESCRIPTION
In this PR, routing to the projects is only allowed when the projects command is used before, which addresses #41. In addition, the user input and a prompt are rendered. The prompt informs the user of which project is being loaded.